### PR TITLE
Uninstalled bat

### DIFF
--- a/homebrew/plugins.txt
+++ b/homebrew/plugins.txt
@@ -1,4 +1,3 @@
-bat
 clojure
 cmake
 erlang


### PR DESCRIPTION
Remove `bat`. I don't need it. 😬 