### PR TITLE
Added python@2

### DIFF
--- a/homebrew/plugins.txt
+++ b/homebrew/plugins.txt
@@ -10,6 +10,7 @@ neovim
 openssl
 pinentry-mac
 python
+python@2
 the_silver_searcher
 tldr
 tmux


### PR DESCRIPTION
## Changes

- Added `python@2` Homebrew package to dev setup.
  - This is to provide Python 2 support in Neovim.