### PR TITLE
fix/nvim-php

### DIFF
--- a/neovim/init.vim
+++ b/neovim/init.vim
@@ -105,8 +105,7 @@ let g:ackprg = 'ag --vimgrep' " Use Ag in place of Ack
 " ALE {{{
 let g:ale_fixers = {
       \ 'c': ['clang-format'],
-      \ 'javascript': ['standard'],
-      \ 'php': ['phpcbf'],
+      \ 'javascript': ['standard']
       \}
 let g:ale_linters = {
       \ 'javascript': ['standard'],


### PR DESCRIPTION
### Removed
- Disabled the `phpcbf` fixer in ALE.
  - It was unable to consistently format files, so I'm gonna do it myself.